### PR TITLE
speed up iOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ jobs:
     if: branch != master or type != push
 
     language: objective-c
+    podfile: ios/Podfile
+    gemfile: ios/Gemfile
     xcode_workspace: ios/Voke.xcworkspace
     os: osx
     osx_image: xcode11.1
@@ -82,6 +84,8 @@ jobs:
     if: branch = master and type = push
 
     language: objective-c
+    podfile: ios/Podfile
+    gemfile: ios/Gemfile
     xcode_workspace: ios/Voke.xcworkspace
     os: osx
     osx_image: xcode11.1
@@ -108,6 +112,7 @@ jobs:
 
     language: android
     dist: trusty
+    gemfile: android/Gemfile
 
     before_install:
     # Fix node file watchers issue https://github.com/gatsbyjs/gatsby/issues/11406#issuecomment-458769756
@@ -148,6 +153,7 @@ jobs:
 
     language: android
     dist: trusty
+    gemfile: android/Gemfile
 
     before_install:
     # Fix node file watchers issue https://github.com/gatsbyjs/gatsby/issues/11406#issuecomment-458769756


### PR DESCRIPTION
It is expected behavior that file modification times will cause rebuilds. In Travis-CI, however, it may not be the modification times, but rather the device inode changes that are causing the derived data to be considered out of date.

```
defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
```